### PR TITLE
GUI: Implement enter keybind for multiline textboxes

### DIFF
--- a/EssaGUI/gui/TextEditor.cpp
+++ b/EssaGUI/gui/TextEditor.cpp
@@ -200,8 +200,18 @@ void TextEditor::handle_event(Event& event) {
             }
             case llgl::KeyCode::Enter: {
                 // TODO: Handle multiline case
-                if (on_enter)
-                    on_enter(get_content());
+                if (m_multiline) {
+                    if (event.event().key.ctrl && on_enter) {
+                        on_enter(get_content());
+                    }
+                    else {
+                        insert_codepoint('\n');
+                    }
+                }
+                else {
+                    if (on_enter)
+                        on_enter(get_content());
+                }
                 break;
             }
             case llgl::KeyCode::Backspace: {

--- a/EssaGUI/gui/TextEditor.hpp
+++ b/EssaGUI/gui/TextEditor.hpp
@@ -50,6 +50,9 @@ public:
     Util::UString selected_text() const;
 
     std::function<void(Util::UString const&)> on_change;
+
+    // The callback that is run when pressing Enter, or Ctrl + Enter
+    // for multiline textboxes.
     std::function<void(Util::UString const&)> on_enter;
 
 private:


### PR DESCRIPTION
By the way, now the on_enter callback is run when pressing Ctrl+Enter on
multiline textboxes :^)
