### PR TITLE
TextEditor tab indenting

### DIFF
--- a/EssaGUI/gui/Container.cpp
+++ b/EssaGUI/gui/Container.cpp
@@ -221,18 +221,22 @@ bool Container::focus_next_widget(bool called_from_child) {
     // if (!called_from_child)
     //     std::cout << "======================RUNNING TAB FOCUS======================" << std::endl;
     auto index = index_opt.value();
+
+    if (m_widgets[index]->steals_focus())
+        return false;
+
     do {
         index++;
         // dump(0);
         // std::cout << "focus_next_widget " << called_from_child << ": " << index << " " << m_widgets.size() << std::endl;
         if (index == m_widgets.size()) {
-            if (m_parent && !isolated_focus())
+            if (m_parent && !steals_focus())
                 m_parent->focus_next_widget(true);
             else
                 focus_first_child_or_self();
             break;
         }
-        else if (m_widgets[index]->is_visible() && m_widgets[index]->accepts_focus()) {
+        else if (m_widgets[index]->is_visible() && m_widgets[index]->accepts_focus() && !m_widgets[index]->steals_focus()) {
             // std::cout << "Focusing first_child_or_self: " << index << std::endl;
             m_widgets[index]->focus_first_child_or_self();
             break;
@@ -248,7 +252,7 @@ void Container::focus_first_child_or_self() {
     }
 
     for (auto& widget : m_widgets) {
-        if (widget->is_visible() && widget->accepts_focus()) {
+        if (widget->is_visible() && widget->accepts_focus() && !widget->steals_focus()) {
             widget->focus_first_child_or_self();
             break;
         }
@@ -256,7 +260,7 @@ void Container::focus_first_child_or_self() {
 }
 
 bool Container::accepts_focus() const {
-    if (isolated_focus())
+    if (steals_focus())
         return false;
     for (auto& widget : m_widgets) {
         if (widget->is_visible() && widget->accepts_focus())

--- a/EssaGUI/gui/Container.hpp
+++ b/EssaGUI/gui/Container.hpp
@@ -194,13 +194,6 @@ protected:
     virtual void focus_first_child_or_self() override;
     virtual bool accepts_focus() const override;
 
-    // Isolated focus - so that the widget cannot be focused from outside
-    // and the focus cannot "escape" the widget using Tab. Used for settings
-    // windows and settings menu so that you can "circulate" all settings
-    // using Tab.
-    // FIXME: Allow user to set it for any container.
-    virtual bool isolated_focus() const { return false; }
-
     std::optional<size_t> focused_widget_index(bool recursive) const;
     // Returns true if the focus changed (one of children was focused)
     bool focus_next_widget(bool called_from_child);

--- a/EssaGUI/gui/Frame.hpp
+++ b/EssaGUI/gui/Frame.hpp
@@ -14,7 +14,7 @@ public:
 private:
     virtual void draw(GUI::Window&) const override;
     virtual float intrinsic_padding() const override { return BorderRadius; }
-    virtual bool isolated_focus() const override { return true; }
+    virtual bool steals_focus() const override { return true; }
 };
 
 }

--- a/EssaGUI/gui/SettingsMenu.hpp
+++ b/EssaGUI/gui/SettingsMenu.hpp
@@ -28,7 +28,7 @@ public:
     MenuEntry& add_entry(llgl::opengl::Texture const& image, Util::UString tooltip, Expandable = Expandable::Yes);
 
 private:
-    virtual bool isolated_focus() const override { return true; }
+    virtual bool steals_focus() const override { return true; }
 
     std::vector<std::unique_ptr<MenuEntry>> m_entries;
     Container* m_buttons_container {};

--- a/EssaGUI/gui/TextEditor.cpp
+++ b/EssaGUI/gui/TextEditor.cpp
@@ -214,6 +214,12 @@ void TextEditor::handle_event(Event& event) {
                 }
                 break;
             }
+            case llgl::KeyCode::Tab: {
+                do {
+                    insert_codepoint(' ');
+                } while (m_cursor.column % 4 != 0);
+                break;
+            }
             case llgl::KeyCode::Backspace: {
                 if (m_lines.size() > 0) {
                     if (m_cursor == m_selection_start) {
@@ -445,11 +451,6 @@ void TextEditor::insert_codepoint(uint32_t codepoint) {
         else {
             return;
         }
-    }
-    else if (codepoint == '\t') {
-        do {
-            insert_codepoint(' ');
-        } while (m_cursor.column % 4 != 0);
     }
     else if (codepoint >= 0x20) {
 

--- a/EssaGUI/gui/TextEditor.hpp
+++ b/EssaGUI/gui/TextEditor.hpp
@@ -60,6 +60,7 @@ private:
     Util::Vector2f calculate_cursor_position() const;
     void erase_selected_text();
     virtual bool accepts_focus() const override { return true; }
+    virtual bool steals_focus() const override { return m_multiline; }
     TextDrawOptions get_text_options() const;
     virtual bool can_insert_codepoint(uint32_t) const { return true; }
     virtual void on_content_change() { }

--- a/EssaGUI/gui/Widget.hpp
+++ b/EssaGUI/gui/Widget.hpp
@@ -156,6 +156,15 @@ protected:
     virtual void update();
     virtual void handle_event(Event&);
     virtual bool accepts_focus() const { return false; }
+
+    // "Steals focus" - so that the widget cannot be focused from outside
+    // and the focus cannot "escape" the widget using Tab. Used for settings
+    // windows and settings menu so that you can "circulate" all settings
+    // using Tab. Also used for multiline TextEditor so that you can use
+    // Tab to indent text.
+    // FIXME: Allow user to set it for any widget.
+    virtual bool steals_focus() const { return false; }
+
     virtual void focus_first_child_or_self();
 
     void set_needs_relayout();


### PR DESCRIPTION
- GUI: Implement "isolated focus" for normal Widgets too
- GUI: Set steals focus for multiline text editors
- GUI: Bring back tab indenting for TextEditors
