### PR TITLE
LLGL+EssaGUI/gfx: Add VertexMapping and Builder API

### DIFF
--- a/EssaEngine/3D/Shaders/Basic.hpp
+++ b/EssaEngine/3D/Shaders/Basic.hpp
@@ -4,6 +4,7 @@
 #include <LLGL/OpenGL/ShaderBases/Texture.hpp>
 #include <LLGL/OpenGL/ShaderBases/Transform.hpp>
 #include <LLGL/OpenGL/Vertex.hpp>
+#include <LLGL/OpenGL/VertexMapping.hpp>
 
 namespace Essa::Shaders {
 
@@ -22,3 +23,10 @@ public:
 };
 
 }
+
+template<>
+struct llgl::VertexMapping<Essa::Shaders::Basic::Vertex> {
+    static constexpr size_t position = 0;
+    static constexpr size_t color = 1;
+    static constexpr size_t tex_coord = 2;
+};

--- a/EssaGUI/gfx/GUIBuilder.hpp
+++ b/EssaGUI/gfx/GUIBuilder.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <EssaGUI/gfx/DefaultGUIShader.hpp>
+#include <LLGL/OpenGL/Builder.hpp>
+#include <LLGL/OpenGL/MappedVertex.hpp>
+#include <LLGL/OpenGL/Projection.hpp>
+#include <LLGL/OpenGL/Renderer.hpp>
+#include <LLGL/OpenGL/Transform.hpp>
+#include <LLGL/OpenGL/VertexArray.hpp>
+#include <vector>
+
+namespace Gfx {
+
+struct GUIBuilderRenderRange : public llgl::RenderRange {
+    llgl::Projection projection;
+};
+
+// Builder optimized for generating 2D GUI components, widgets etc.
+class GUIBuilder : public llgl::Builder<Vertex, GUIBuilderRenderRange> {
+public:
+    void add_rectangle(Util::Rectf const& rect, Util::Colorf const& color = Util::Colors::White, Util::Rectf const& texture_rect = {}) {
+        add({
+            create_vertex(Util::Vector3f { rect.left, rect.top, 0 }, color,
+                Util::Vector2f { texture_rect.left, texture_rect.top }, Util::Vector3f {}),
+            create_vertex(Util::Vector3f { rect.left + rect.width, rect.top, 0 }, color,
+                Util::Vector2f { texture_rect.left + texture_rect.width, texture_rect.top }, Util::Vector3f {}),
+            create_vertex(Util::Vector3f { rect.left, rect.top + rect.height, 0 }, color,
+                Util::Vector2f { texture_rect.left, texture_rect.top + texture_rect.height }, Util::Vector3f {}),
+            create_vertex(Util::Vector3f { rect.left + rect.width, rect.top + rect.height, 0 }, color,
+                Util::Vector2f { texture_rect.left + texture_rect.width, texture_rect.top + texture_rect.height }, Util::Vector3f {}),
+        });
+        add_render_range_for_last_vertices(4, llgl::PrimitiveType::TriangleStrip, m_projection);
+    }
+
+    void add_regular_polygon(Util::Vector2f center, float radius, size_t vertices, Util::Colorf const& color = Util::Colors::White) {
+        for (size_t s = 0; s < vertices; s++) {
+            float angle = 6.28 * s / vertices;
+            Util::Vector2f vpos { radius * std::sin(angle), radius * std::cos(angle) };
+            add(create_vertex(Util::Vector3f(vpos + center, 0), color, Util::Vector2f {}, Util::Vector3f {}));
+        }
+        add(create_vertex(Util::Vector3f(Util::Vector2f { 0, radius } + center, 0), color, Util::Vector2f {}, Util::Vector3f {}));
+        add_render_range_for_last_vertices(vertices + 1, llgl::PrimitiveType::TriangleFan, m_projection);
+    }
+
+    void set_projection(llgl::Projection projection) { m_projection = std::move(projection); }
+
+private:
+    using llgl::Builder<Vertex, GUIBuilderRenderRange>::create_vertex;
+    using llgl::Builder<Vertex, GUIBuilderRenderRange>::add;
+    using llgl::Builder<Vertex, GUIBuilderRenderRange>::add_render_range_for_last_vertices;
+
+    virtual void render_range(llgl::Renderer& renderer, llgl::VertexArray<Vertex> const& vao, GUIBuilderRenderRange const& range) const override {
+        static Gfx::DefaultGUIShader shader;
+        shader.set_projection_matrix(m_projection.matrix());
+        llgl::set_viewport(m_projection.viewport());
+        renderer.draw_vertices(vao, llgl::DrawState { shader, range.type }, range.first, range.size);
+    }
+
+    llgl::Projection m_projection;
+};
+
+}

--- a/EssaGUI/gfx/Vertex.hpp
+++ b/EssaGUI/gfx/Vertex.hpp
@@ -3,6 +3,7 @@
 #include <EssaUtil/Color.hpp>
 #include <EssaUtil/Vector.hpp>
 #include <LLGL/OpenGL/Vertex.hpp>
+#include <LLGL/OpenGL/VertexMapping.hpp>
 
 namespace Gfx {
 
@@ -25,3 +26,10 @@ public:
 };
 
 }
+
+template<>
+struct llgl::VertexMapping<Gfx::Vertex> {
+    static inline constexpr size_t position = 0;
+    static inline constexpr size_t color = 1;
+    static inline constexpr size_t tex_coord = 2;
+};

--- a/LLGL/OpenGL/Builder.hpp
+++ b/LLGL/OpenGL/Builder.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "LLGL/OpenGL/PrimitiveType.hpp"
+#include <LLGL/OpenGL/MappedVertex.hpp>
+#include <LLGL/OpenGL/Renderer.hpp>
+#include <LLGL/OpenGL/VertexArray.hpp>
+
+namespace llgl {
+
+struct RenderRange {
+    size_t first;
+    size_t size;
+    llgl::PrimitiveType type;
+};
+
+// A class which simplifies generating VAOs and abstract away
+// all modifications to it
+template<class Vertex, class RR>
+requires std::is_base_of_v<RenderRange, RR>
+class Builder {
+public:
+    using MappedVertex = llgl::MappedVertex<Vertex>;
+    using StoredRenderRange = RR;
+
+    virtual ~Builder() = default;
+
+    void add(std::initializer_list<Vertex> v) {
+        m_vertices.insert(m_vertices.begin(), v.begin(), v.end());
+        set_modified();
+    }
+
+    void add(Vertex v) {
+        m_vertices.push_back(std::move(v));
+        set_modified();
+    }
+
+    void render(llgl::Renderer& renderer) const {
+        if (m_was_modified) {
+            m_vao.upload_vertices(m_vertices);
+        }
+        if (m_ranges.empty()) {
+            render_range(renderer, m_vao, { 0, m_vertices.size(), llgl::PrimitiveType::Triangles });
+        }
+        else {
+            for (auto const& range : m_ranges) {
+                render_range(renderer, m_vao, range);
+            }
+        }
+    }
+
+protected:
+    static Vertex create_vertex(auto position, auto color, auto tex_coord, auto normal) {
+        Vertex vertex;
+        llgl::MappedVertex<Vertex> mapped { vertex };
+        if constexpr (MappedVertex::HasPosition)
+            mapped.set_position(position);
+        if constexpr (MappedVertex::HasColor)
+            mapped.set_color(color);
+        if constexpr (MappedVertex::HasTexCoord)
+            mapped.set_tex_coord(tex_coord);
+        if constexpr (MappedVertex::HasNormal)
+            mapped.set_normal(normal);
+        return vertex;
+    }
+
+    void set_modified() { m_was_modified = true; }
+
+    template<class... Args>
+    void add_render_range_for_last_vertices(size_t count, llgl::PrimitiveType pt, Args&&... args) {
+        m_ranges.push_back(StoredRenderRange { m_vertices.size() - count, count, pt, std::forward<Args>(args)... });
+    }
+
+private:
+    virtual void render_range(llgl::Renderer&, llgl::VertexArray<Vertex> const&, StoredRenderRange const&) const {};
+
+    mutable llgl::VertexArray<Vertex> m_vao;
+    std::vector<Vertex> m_vertices;
+    mutable bool m_was_modified = false;
+    std::vector<StoredRenderRange> m_ranges;
+};
+
+}

--- a/LLGL/OpenGL/MappedVertex.hpp
+++ b/LLGL/OpenGL/MappedVertex.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "VertexMapping.hpp"
+
+namespace llgl {
+
+template<class T>
+concept Empty = std::is_empty_v<T>;
+
+template<class T>
+concept MappableVertex = requires(T v) {
+    v.template value<0>();
+    { VertexMapping<T>() } -> Empty;
+};
+
+#define DEFINE_NAMED_ATTRIBUTE(snake_case, PascalCase)                                                                             \
+    static constexpr bool Has##PascalCase = requires() { Mapping::snake_case; };                                                   \
+                                                                                                                                   \
+    auto snake_case() const requires Has##PascalCase {                                                                             \
+        return m_vertex.template value<Mapping::snake_case>();                                                                     \
+    }                                                                                                                              \
+    void set_##snake_case(auto v) requires Has##PascalCase {                                                                       \
+        m_vertex.template value<Mapping::snake_case>()                                                                             \
+            = static_cast<std::remove_reference_t<decltype(std::declval<VertexType>().template value<Mapping::snake_case>())>>(v); \
+    }
+
+template<MappableVertex V>
+class MappedVertex {
+public:
+    using VertexType = V;
+
+    MappedVertex(VertexType& v)
+        : m_vertex(v) { }
+
+    using Mapping = VertexMapping<V>;
+
+    DEFINE_NAMED_ATTRIBUTE(position, Position)
+    DEFINE_NAMED_ATTRIBUTE(color, Color)
+    DEFINE_NAMED_ATTRIBUTE(tex_coord, TexCoord)
+    DEFINE_NAMED_ATTRIBUTE(normal, Normal)
+
+private:
+    V& m_vertex;
+};
+
+#undef DEFINE_NAMED_ATTRIBUTE
+
+}

--- a/LLGL/OpenGL/Renderer.hpp
+++ b/LLGL/OpenGL/Renderer.hpp
@@ -30,6 +30,13 @@ public:
         vbo.draw(draw_state.primitive_type());
     }
 
+    template<class VertT, class DSS>
+    requires(IsSameVertexLayout<typename DSS::Vertex, VertT>) void draw_vertices(VertexArray<VertT> const& vbo, DrawState<DSS> const& draw_state, size_t first, size_t size) {
+        bind_if_not_bound(m_fbo);
+        draw_state.apply();
+        vbo.draw(draw_state.primitive_type(), first, size);
+    }
+
 private:
     static void bind_if_not_bound(unsigned fbo);
 

--- a/LLGL/OpenGL/Vertex.hpp
+++ b/LLGL/OpenGL/Vertex.hpp
@@ -35,6 +35,10 @@ public:
 
     using AttributePack = ParameterPack<Attributes...>;
 
+    constexpr Vertex() {
+        emplace_values<0>(Attributes {}...);
+    }
+
     constexpr Vertex(Attributes... attrs) {
         emplace_values<0>(std::forward<Attributes>(attrs)...);
     }

--- a/LLGL/OpenGL/VertexArray.hpp
+++ b/LLGL/OpenGL/VertexArray.hpp
@@ -6,6 +6,7 @@
 #include "Vertex.hpp"
 #include <EssaUtil/Color.hpp>
 #include <EssaUtil/Vector.hpp>
+#include <cassert>
 #include <fmt/ostream.h>
 #include <type_traits>
 #include <utility>
@@ -127,6 +128,13 @@ public:
             glDrawElements(static_cast<GLenum>(type), m_vertex_count, GL_UNSIGNED_INT, nullptr);
         else
             glDrawArrays(static_cast<GLenum>(type), 0, m_vertex_count);
+    }
+
+    void draw(llgl::PrimitiveType type, size_t first, size_t size) const {
+        // fmt::print("VAO: Drawing {} vertices with pt={}\n", m_vertex_count, static_cast<int>(type));
+        bind();
+        assert(!m_index_buffer);
+        glDrawArrays(static_cast<GLenum>(type), first, size);
     }
 
 private:

--- a/LLGL/OpenGL/VertexMapping.hpp
+++ b/LLGL/OpenGL/VertexMapping.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace llgl {
+
+// A structure to be specialized to define attribute name -> ID mappings
+template<class T>
+struct VertexMapping;
+
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,7 @@ add_example("essa-gui/text-editor")
 add_example("essa-gui/theme-ini")
 add_example("essa-gui/tooltips")
 add_example("essa-gui/tree-view")
+add_example("essa-gui/gui-builder")
 
 add_example("llgl/experimental-shadergen")
 

--- a/examples/essa-gui/gui-builder.cpp
+++ b/examples/essa-gui/gui-builder.cpp
@@ -1,0 +1,39 @@
+#include <EssaEngine/3D/Shaders/Basic.hpp>
+#include <EssaEngine/Util/VAOBuilder.hpp>
+#include <EssaGUI/gfx/GUIBuilder.hpp>
+#include <EssaGUI/gfx/Vertex.hpp>
+#include <EssaGUI/gui/Application.hpp>
+#include <EssaGUI/gui/WorldView.hpp>
+#include <LLGL/Core/Transform.hpp>
+#include <LLGL/OpenGL/PrimitiveType.hpp>
+#include <fmt/ostream.h>
+
+class WorldView : public GUI::WorldView {
+private:
+    virtual void draw(GUI::Window& window) const override {
+        Gfx::GUIBuilder builder;
+        builder.set_projection(llgl::Projection::ortho({ Util::Rectd { 0, 0, 220 * raw_size().x() / raw_size().y(), 220 } }, Util::Recti { rect() }));
+        builder.add_rectangle({ 25, 25, 50, 50 }, Util::Colors::Red);
+        builder.add_rectangle({ 145, 145, 50, 50 }, Util::Colors::Green);
+        builder.add_regular_polygon({ 110, 110 }, 25, 5, Util::Colors::LightBlue);
+        builder.add_regular_polygon({ 50, 160 }, 25, 3, Util::Colors::LightYellow);
+        builder.add_regular_polygon({ 160, 50 }, 25, 30, Util::Colors::DarkSlateGray);
+        builder.render(window.renderer());
+    }
+};
+
+using Vert = llgl::Vertex<Util::Vector2f, Util::Colorf, Util::Vector2f>;
+template<>
+struct llgl::VertexMapping<Vert> {
+    static constexpr size_t position = 0;
+    static constexpr size_t color = 1;
+    static constexpr size_t tex_coord = 2;
+};
+
+int main() {
+    GUI::Application app;
+    auto& window = app.create_host_window({ 440, 440 }, "VAO Builder example");
+    window.set_main_widget<WorldView>();
+    app.run();
+    return 0;
+}


### PR DESCRIPTION
## MappedVertex
The llgl::MappedVertex class allows settings vertex attributes using
their "intuitive" names (position, color etc.). This requires
a llgl::VertexMapping struct specialization for the vertex to be present
so that MappedVertex knows which attribute is position, which is color
etc.

## Builder
llgl::Builder and its descendants (the only is GUIBuilder for now) are
convenience classes to make high-level rendering much simpler. It is
meant to simplify tasks like "draw a rectangle", while still maintaining
performance by feeding shapes to a single VAO.

The GUIBuilder has functions for adding basic 2D shapes (currently
rectangle and regular polygon). It is meant to replace GUI::Window
draw_* functions in the future.